### PR TITLE
Set wrap and spell by default.

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -12,6 +12,8 @@ unlet! b:did_ftplugin
 setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=>\ %s
 setlocal formatoptions+=tcqln
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+
+setlocal wrap
+setlocal spell
 
 let b:undo_ftplugin .= "|setl cms< com< fo<"
 


### PR DESCRIPTION
I find myself setting these two settings frequently, I figured they make sense when writing in Markdown.

When using Markdown you're probably writing documentation or blog posts, in both cases you probably want it spell checked. Since Markdown doesn't have a code formatter like other languages, wrapping the text probably makes sense too.

Let me know what you think. Thanks.
