### PR TITLE
fixes warning about b:undo_ftplugin not existing, and double loading of plugin in eg, macVim

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -13,6 +13,11 @@ setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=>\ %s
 setlocal formatoptions+=tcqln
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+
 
-let b:undo_ftplugin .= "|setl cms< com< fo<"
+if exists("b:undo_ftplugin") 
+  let b:undo_ftplugin .= "|setl cms< com< fo<"
+else
+  let b:undo_ftplugin = "setl cms< com< fo<"
+endif
 
+let b:did_ftplugin = 1
 " vim:set sw=2:


### PR DESCRIPTION
Somehow the b:undo_ftplugin was not being set by the html plugins ? Just added a check if it exists, and change the assignment.

Also, b:did_ftplugin was not being set, which was causing the above error to show up twice, since MacVim has this plugin in its runtime (so it might be nice to update their version also). Seems I was not the only one to encounter this error : http://code.google.com/p/macvim/issues/detail?id=327
