### PR TITLE
fix performance issue with detecting setext-style headers

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -21,8 +21,8 @@ syn match markdownLineStart "^[<@]\@!" nextgroup=@markdownBlock
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule
 syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop
 
-syn match markdownH1 ".\+\n=\+$" contained contains=@markdownInline,markdownHeadingRule
-syn match markdownH2 ".\+\n-\+$" contained contains=@markdownInline,markdownHeadingRule
+syn match markdownH1 "^.\+\n=\+$" contained contains=@markdownInline,markdownHeadingRule
+syn match markdownH2 "^.\+\n-\+$" contained contains=@markdownInline,markdownHeadingRule
 
 syn match markdownHeadingRule "^[=-]\+$" contained
 


### PR DESCRIPTION
The current setext-style header rules are O(n^2) which makes the entire markdown highlighting very slow.

Because the current rules do not work for nested setext headers anyway (some parsers do support this though) we can make it significantly faster by only checking the match at the start of the line.
