### PR TITLE
add folding support

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -14,4 +14,32 @@ setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+
 
 let b:undo_ftplugin .= "|setl cms< com< fo<"
 
+if has("folding") && exists("g:markdown_folding")
+  setlocal foldexpr=MarkdownFold()
+  setlocal foldmethod=expr
+  let b:undo_ftplugin .= " foldexpr< foldmethod<"
+
+  function! MarkdownFold()
+    let line = getline(v:lnum)
+
+    " Regular headers
+    let depth = match(line, '\(^#\+\)\@<=\( .*$\)\@=')
+    if depth > 0
+      return ">" . depth
+    endif
+
+    " Setext style headings
+    let nextline = getline(v:lnum + 1)
+    if (line =~ '^.\+$') && (nextline =~ '^=\+$')
+      return ">1"
+    endif
+
+    if (line =~ '^.\+$') && (nextline =~ '^-\+$')
+      return ">2"
+    endif
+
+    return "="
+  endfunction
+endif
+
 " vim:set sw=2:


### PR DESCRIPTION
I added folding support for regular and setext headers. Folding is disabled by default but can be enabled by assigning a value (such as 1) to `g:markdown_folding`.
