### PR TITLE
highlight YAML frontmatter, as in Jekyll/Octopress

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -71,6 +71,10 @@ syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*\zs```\s*\w*
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
 
+" highlight YAML frontmatter
+syn include @yamlTop syntax/yaml.vim
+syntax match Comment /\%^---\_$\_.\{-}\_^---$/ contains=@yamlTop
+
 hi def link markdownH1                    htmlH1
 hi def link markdownH2                    htmlH2
 hi def link markdownH3                    htmlH3


### PR DESCRIPTION
I'm not sure if this is true with everyone else, but 90% of the time I'm using markdown, I'm using a framework that parses YAML frontmatter.

The change here should only highlight documents that begin with `---\n`, so I think it's pretty unobtrusive.  What do you think?
