### PR TITLE
Fixing some italics syntax consistency issues

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -58,8 +58,15 @@ syn region markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" conta
 syn region markdownId matchgroup=markdownIdDelimiter start="\[" end="\]" keepend contained
 syn region markdownAutomaticLink matchgroup=markdownUrlDelimiter start="<\%(\w\+:\|[[:alnum:]_+-]\+@\)\@=" end=">" keepend oneline
 
-syn region markdownItalic start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" keepend contains=markdownLineStart
-syn region markdownItalic start="\S\@<=_\|_\S\@=" end="\S\@<=_\|_\S\@=" keepend contains=markdownLineStart
+" Explanation of italics pattern when token is '_':
+"   match start on '_' that is:
+"   * followed by a non-space character
+"   * NOT followed by two newline chars (separated by any non-newline whitespace) that are
+"   preceded by:
+"     * all non-'_' characters OR
+"     * an '_' that is ignored for ending italics ('_' preceded by whitespace)
+syn region markdownItalic start="\*\S\@=\(\(\_[^*]\|\_\s\*\)\{-}\n\s*\n\)\@!" end="\S\@<=\*" skip="\\\*" keepend contains=markdownLineStart
+syn region markdownItalic start="_\S\@=\(\(\_[^_]\|\_\s_\)\{-}\n\s*\n\)\@!" end="\S\@<=_" skip="\\_" keepend contains=markdownLineStart
 syn region markdownBold start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend contains=markdownLineStart
 syn region markdownBold start="\S\@<=__\|__\S\@=" end="\S\@<=__\|__\S\@=" keepend contains=markdownLineStart
 syn region markdownBoldItalic start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart

--- a/syntax/sample.md
+++ b/syntax/sample.md
@@ -1,0 +1,58 @@
+This is a sample markdown file for testing syntax.vim. The highlighting in this file should be consistent with what is generated when ran through the Markdown Dingus (whatever a "dingus" is) at <http://daringfireball.net/projects/markdown/dingus>.
+
+- - - -
+
+ITALICS
+
+- - - -
+
+
+
+abc
+_ abc_
+
+  _abc_
+
+ ab*c
+  
+  *abc*
+
+_abc
+
+  def_
+
+Abc _123_:
+
+abc _under\_score_
+abc
+_ abc_aa_
+
+  _  abc_
+
+_ab
+cde_
+
+_abc _
+The 2nd underscore in the line above is ignored as the end of italics because its surrounded by spaces._
+
+_abc _
+
+Neither 'abc' above or this line are italicized because of the transition to another paragraph._
+This line is also not italic because, although the end of the previous line has an underscore, and this line is in the same paragraph, you can't start italics at the end of a line._
+
+Below, 'cd' is italicized across a line because they're still in the same paragraph.
+_ ab_c
+d_abc
+
+Below, the 'c' is not italicized across a line like the previous example because the '\_' on the 2nd line starts with a non-word char.
+_ ab_c
+_abc
+
+Unlike the above example, there *is* a valid ending '\_', so it creates italics.
+_ ab_c
+_abc_
+
+_ ab_c
+ _
+
+  _abc_


### PR DESCRIPTION
- Added skipping escaped italics tokens when end matching
- Updated prefix/suffix constraints for start/end patterns to be more consistent with behavior of the Markdown Dingus
- Added constraint on start pattern so that it doesn't match if there isn't an end token within the same paragraph
- Added sample.md to syntax dir to use for testing syntax consistency w/the dingus
