### PR TITLE
Support for footnotes, embedded html

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -58,6 +58,10 @@ syn region markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" conta
 syn region markdownId matchgroup=markdownIdDelimiter start="\[" end="\]" keepend contained
 syn region markdownAutomaticLink matchgroup=markdownUrlDelimiter start="<\%(\w\+:\|[[:alnum:]_+-]\+@\)\@=" end=">" keepend oneline
 
+syn region markdownFn matchgroup=markdownFnDelimiter start="^\[^"rs=e-1 end="\]:" nextgroup=markdownFnText contains=markdownFnId skipwhite oneline
+syn match markdownFnId "\^[^]]\{-1,\}" contained 
+syn match markdownFnText "\s*\(\n*\( {4}\|\t\)\|.*\)\+" contains=@markdownInline,@markdownBlock contained
+
 syn region markdownItalic start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" keepend contains=markdownLineStart
 syn region markdownItalic start="\S\@<=_\|_\S\@=" end="\S\@<=_\|_\S\@=" keepend contains=markdownLineStart
 syn region markdownBold start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend contains=markdownLineStart
@@ -93,6 +97,10 @@ hi def link markdownUrlTitle              String
 hi def link markdownIdDelimiter           markdownLinkDelimiter
 hi def link markdownUrlDelimiter          htmlTag
 hi def link markdownUrlTitleDelimiter     Delimiter
+
+hi def link markdownFnId                  Type
+hi def link markdownFnIdDelimiter         markdownLinkDelimiter
+hi def link markdownFnText                Comment
 
 hi def link markdownItalic                htmlItalic
 hi def link markdownBold                  htmlBold

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -35,7 +35,7 @@ syn region markdownH6 matchgroup=markdownHeadingDelimiter start="#######\@!" end
 
 syn match markdownBlockquote ">\s" contained nextgroup=@markdownBlock
 
-syn region markdownCodeBlock start="    \|\t" end="$" contained
+syn region markdownCodeBlock start="\n\+\(    \|\t\)[^<]" end="^\t\@!" contained
 
 " TODO: real nesting
 syn match markdownListMarker "\%(\t\| \{0,4\}\)[-*+]\%(\s\+\S\)\@=" contained


### PR DESCRIPTION
This is my first ever attempt at anything syntax related for vim, so please keep that in mind. I really don't know what I'm doing :)

But this pull adds support for highlighting footnotes as defined by markdown-extra. I'm not sold on linking `markdownFnText` to `Comment`, but it does set it off nicely visually, while retaining embedded highlighting for things like bold, italics, and links.

It supports footnotes of the following style:

``` markdown
[^1]: This is a standard footnote, it can have [links](http://google.com) and nearly _anything_ else, including blocks (technically, not from this syntax highlighting).

[^2]:
    This is also a footnote, which allows for better formatting for multiple paragraphs.

    This is another paragraph of footnote 2.

[^3]: The two styles can also be combined.

    See, this is still part of footnote 3!
```

Also contained is just something I fixed along the way. If HTML is embedded in the document, then the inner level of it was being marked as a code block.

Example HTML (`a`, `iframe`, and `figcaption` were being marked as code):

``` html
<figure>
    <a id="fig-1"></a>
    <iframe 
        style="width: 100%; height: 465px" 
        src="http://jsfiddle.net/embedded/result" 
        allowfullscreen="allowfullscreen" 
        frameborder="0">
    </iframe>
    <figcaption>
        Some text here
    </figcaption>
</figure>
```

Again, this is my first vim syntax attempt, so any suggestions / tips are extremely welcome.
