### PR TITLE
Highlighting Fenced Code Blocks

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -76,8 +76,8 @@ for s:lang in g:markdown_gfm_languages
   let s:lang_name = matchstr(s:lang, "^[^=]*")
   let s:lang_syntax = matchstr(s:lang, "[^=]*$")
 
-  exe "syn include @highlight_code_block_" . s:lang_syntax . " syntax/" . s:lang_syntax . ".vim"
-  exe "syn region markdownCode_" . s:lang_syntax . ' matchgroup=markdownCodeDelimiter start="^\s*\zs```' . s:lang_name . '$" end="^```\ze\s*$" keepend contains=@highlight_code_block_' . s:lang_syntax
+  exe "syn include @markdownCode_" . s:lang_syntax . " syntax/" . s:lang_syntax . ".vim"
+  exe "syn region markdownCode_" . s:lang_syntax . ' matchgroup=markdownCodeDelimiter start="^\s*\zs```' . s:lang_name . '$" end="^```\ze\s*$" keepend contains=@markdownCode_' . s:lang_syntax
   unlet! b:current_syntax
 endfor
 unlet! s:lang s:lang_name s:lang_syntax


### PR DESCRIPTION
I wanted this, and perusing through the issues, found one about this: #17.

I took a look at vim-liquid and the `fenced_highlighting` branch - it looked like
the `fenced_highlighting` branch was accidentally trying to use a variable
from the liquid code (copy-paste error?).

I cleaned it up a little bit and it seems to work now. The commit message is below

<hr/>

Introduces a global variable: g:markdown_gfm_languages, which
should be set to a list of values:

```
let g:markdown_gfm_languages = ["ruby", "erb=eruby"]
```

Given those values, code blocks of the form "`ruby <ruby code>`"
will be highlighted using the "ruby" highlighter.

Similarly, "`erb <erb code>`" will use the "eruby" highlighter.
