### PR TITLE
A more liberal markdownValid

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -29,7 +29,7 @@ unlet! s:type
 syn sync minlines=10
 syn case ignore
 
-syn match markdownValid '[<>]\S\@!'
+syn match markdownValid '[<>]\c[a-z/$!]\@!'
 syn match markdownValid '&\%(#\=\w*;\)\@!'
 
 syn match markdownLineStart "^[<@]\@!" nextgroup=@markdownBlock


### PR DESCRIPTION
It appears Markdown uses the following regex to find the beginning of a tag:

```
<[a-z/!$]  # Markdown.pl:1276 from version 1.0.1.
```

This means, for example, `<=` would not be a considered a tag.

Currently, it _is_ considered a tag. Curiously this can sometimes lead to the behavior witnessed in #29, where things kind-of look okay until you use a `'` somewhere after your `<`. The `'` then has the syntax stack `htmlTag -> htmlString` and things go all wacky. (Well, things already _were_ all wacky, since everything after the `<=` is considered internal to a tag.)

This patch makes markdownValid more liberal, looking a bit more like Markdown's regex. It may fix some cases of #29.
