### PR TITLE
Require space after ordered list marker

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -55,7 +55,7 @@ syn region markdownCodeBlock start="    \|\t" end="$" contained
 
 " TODO: real nesting
 syn match markdownListMarker "\%(\t\| \{0,4\}\)[-*+]\%(\s\+\S\)\@=" contained
-syn match markdownOrderedListMarker "\%(\t\| \{0,4}\)\<\d\+\.\%(\s*\S\)\@=" contained
+syn match markdownOrderedListMarker "\%(\t\| \{0,4}\)\<\d\+\.\%(\s\+\S\)\@=" contained
 
 syn match markdownRule "\* *\* *\*[ *]*$" contained
 syn match markdownRule "- *- *-[ -]*$" contained


### PR DESCRIPTION
This patch fixes the issue where `0.` in the following Markdown heading is incorrectly highlighted as an ordered list marker:

```
0.2.0   Mon Dec 3 18:27:18 2012 +0000
-----
* Add missing `#ctcp_type` and `#dcc_type` accessors
* Make `#type`, `#ctcp_type`, and `#dcc_type` return symbols, not strings
```
