### PR TITLE
Clear `main_syntax` if we set it.

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -126,5 +126,8 @@ hi def link markdownEscape                Special
 hi def link markdownError                 Error
 
 let b:current_syntax = "markdown"
+if main_syntax ==# 'markdown'
+  unlet main_syntax
+endif
 
 " vim:set sw=2:


### PR DESCRIPTION
This prevents conflicts with other syntaxes that use `main_syntax`, like 
vim-javascript.

Fixes an issue when vim-javascript and vim-markdown are both loaded in which
loading a markdown file prevents all future JavaScript buffers from using
conceal.
