### PR TITLE
Add highlighting for trailing whitespace

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -92,6 +92,7 @@ if main_syntax ==# 'markdown'
 endif
 
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
+syn match markdownImplicitBreak "\s*\ \ $" containedin=ALL
 syn match markdownError "\w\@<=_\w\@="
 
 hi def link markdownH1                    htmlH1
@@ -123,6 +124,7 @@ hi def link markdownBoldItalic            htmlBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
 
 hi def link markdownEscape                Special
+hi def      markdownImplicitBreak         ctermbg=darkgreen guibg=lightgreen
 hi def link markdownError                 Error
 
 let b:current_syntax = "markdown"


### PR DESCRIPTION
Double spaces are used in markdown to trigger a hard linebreak
