### PR TITLE
Jekyll-style liquid code tags

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -84,6 +84,7 @@ syn region markdownBoldItalic start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*```.*$" end="^\s*```\ze\s*$" keepend
+syn region markdownCode matchgroup=markdownCodeDelimiter start=/{[%{].*[}%]}/ end="{%\s*endhighlight\s*%}" keepend
 
 syn match markdownFootnote "\[^[^\]]\]\s*$"
 syn match markdownFootnoteDefinition "^\[^[^\]]\]:"


### PR DESCRIPTION
Add support for Jekyll-style liquid code tags, as described here:
http://jekyllrb.com/docs/posts/

```
{% highlight ruby %}
# sample ruby code
["do", "dont do"].include? "try"  #=> false
{% endhighlight %}
```
