### PR TITLE
Support alternative code block syntax highlighting of pandoc

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -90,7 +90,7 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\]:"
 
 if main_syntax ==# 'markdown'
   for s:type in g:markdown_fenced_languages
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```\s*\({.*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
   endfor
   unlet! s:type
 endif

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -90,7 +90,7 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\]:"
 
 if main_syntax ==# 'markdown'
   for s:type in g:markdown_fenced_languages
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```\s*\({.*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z([`~]\{3,}\)\s*\({.*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*\z1[`~]*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
   endfor
   unlet! s:type
 endif

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -90,7 +90,7 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\]:"
 
 if main_syntax ==# 'markdown'
   for s:type in g:markdown_fenced_languages
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z([`~]\{3,}\)\s*\({.*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*\z1[`~]*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\([`~]\)\)\z(\1\{2,}\)\s*\({.*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*\z1\z2\z1*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
   endfor
   unlet! s:type
 endif


### PR DESCRIPTION
Pandoc provides a second possibility for code block syntax highlighting:

``````
  ``` {#mycode .haskell .numberLines startFrom="100"}
  qsort []     = []
``````

```
```
