### PR TITLE
markdown'ed code in same color as code delimiter

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -128,6 +128,7 @@ hi def link markdownItalic                htmlItalic
 hi def link markdownBold                  htmlBold
 hi def link markdownBoldItalic            htmlBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
+hi def link markdownCode                  Delimiter
 
 hi def link markdownEscape                Special
 hi def link markdownError                 Error


### PR DESCRIPTION
Sometimes, I forgot to add an ending code delimiter (backticks) in a markdown file, so I made a change into the VIm syntax by adding a color to the code part, they now have the same color as the code delimiter. I've found it's an improvement on readability, so I hope this is worth a PR.
