### PR TITLE
A few fixes to inline styles and code blocks

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -92,7 +92,9 @@ exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter' s:Inl
 
 exe 'syn region markdownCode matchgroup=markdownCodeDelimiter' s:InlineRegionPatterns('`\%(``\)\@!', '`') 'keepend contains=markdownLineStart'
 exe 'syn region markdownCode matchgroup=markdownCodeDelimiter' s:InlineRegionPatterns('`\@1<!```\@! \=', ' \=``') 'keepend contains=markdownLineStart'
-syn region markdownFencedCode matchgroup=markdownCodeFence start="\s*```.*$" end="^\s*```\ze\s*$" contained keepend
+" experimentally, markdown code fences do not require match start/end markers,
+" they only care that the start/end markers are independently valid.
+syn region markdownFencedCode matchgroup=markdownCodeFence start="\s*```.*$" start="\s*\~\{3}.*$" end="^\s*`\{3,}\ze\s*$" end="^\s*\~\{3,}\ze\s*$" contained keepend
 syn cluster markdownBlock add=markdownFencedCode
 
 syn match markdownFootnote "\[^[^\]]\+\]"


### PR DESCRIPTION
This contains various fixes, including:
- Inline styles shouldn't work across blank lines.
- Inline styles shouldn't highlight if the close token isn't present.
- `[link text][destination]` blocks should allow a newline where currently only a single space is allowed.
- Fenced code blocks can start after blockquotes, like other block-level elements.
- Blockquotes shouldn't require the space.
- More flexible fenced code block start/end tokens.

I think this at least partially obsoletes #16.
