### PR TITLE
highlight fenced code with pandoc style attributes

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -92,7 +92,11 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\+\]:"
 
 if main_syntax ==# 'markdown'
   for s:type in g:markdown_fenced_languages
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').
+                \' matchgroup=markdownCodeDelimiter '.
+                \'start="^\s*```\s*'.matchstr(s:type,'[^=]*').'\>.*$" '.
+                \'end="^\s*```\ze\s*$" '.
+                \'keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
   endfor
   unlet! s:type
 endif

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -94,7 +94,7 @@ if main_syntax ==# 'markdown'
   for s:type in g:markdown_fenced_languages
     exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').
                 \' matchgroup=markdownCodeDelimiter '.
-                \'start="^\s*```\s*'.matchstr(s:type,'[^=]*').'\>.*$" '.
+                \'start="^\s*```\s*\%({[^.]*\.\)\='.matchstr(s:type,'[^=]*').'\>.*$" '.
                 \'end="^\s*```\ze\s*$" '.
                 \'keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
   endfor


### PR DESCRIPTION
This PR modifies the fenced code matching pattern to allow a
language specifier inside pandoc style attributes.

The behaviour before this commit was to embed language highlighting in
code blocks with the language specifed as in github-flavored-markdown,
i.e.

``````
```python
print 1
```
``````

Following this commit, the language can be specified inside pandoc style
attributes.

Pandoc markdown allows attributes on fenced code, e.g.

``````
```{#id .class key=value}
code
```
``````

the order of these attributes does not matter.

One of the 'class' arguments can be a code syntax specifier, e.g.

``````
```{#id .python}
print 1
```
``````

N.B. Github currently renders language specified in pandoc style
attributes if the language is the first class specified, i.e.

``````
```{.python .whatever #id}
print 1
```
``````

There is a pandoc specific syntax highlighter in [vim-pandoc](https://github.com/vim-pandoc/vim-pandoc-syntax), but seeing as
github parses these attributes I think it makes sense to include them in here.
