### PR TITLE
Add syntax match for horizontal rules to fix highlight problems.

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -82,6 +82,7 @@ exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=\*\*\
 exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=__\|__\S\@=" end="\S\@<=__\|__\S\@=" keepend contains=markdownLineStart,markdownItalic' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart' . s:concealends
+syn match htmlHorizontalRule "\v^(((\*|\-|_)\s{0,1})+){3,}$"
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
@@ -133,6 +134,7 @@ hi def link markdownBoldDelimiter         markdownBold
 hi def link markdownBoldItalic            htmlBoldItalic
 hi def link markdownBoldItalicDelimiter   markdownBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
+hi def link htmlHorizontalRule            Comment
 
 hi def link markdownEscape                Special
 hi def link markdownError                 Error


### PR DESCRIPTION
Currently when you add a horizontal rule via ***, it will try to highlight any following characters as italics until you close the asterisk. Quite annoying if you use HRs, or even just use asterisks to visually break content apart while editing.
