### PR TITLE
Add escape support for angle braces

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -97,7 +97,7 @@ if main_syntax ==# 'markdown'
   unlet! s:type
 endif
 
-syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
+syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
 
 hi def link markdownH1                    htmlH1


### PR DESCRIPTION
I noticed that vim markdown wasn't treating escaped angle braces as escaped.  This change helps vim markdown syntax match escaped angle braces so they are not matched as html tag delimiters.

    Escaped like \<b>this\</b> means it is _not_ an <b>html<b> tag.

Escaped like \<b>this\</b> means it is _not_ an <b>html</b> tag.