### PR TITLE
Add CriticMarkup highlighting

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -47,4 +47,11 @@ if has("folding") && exists("g:markdown_folding")
   let b:undo_ftplugin .= " foldexpr< foldmethod<"
 endif
 
+" Surround.vim bindings - install surround.vim first
+let b:surround_43 = "{++\r++}" " +
+let b:surround_45 = "{--\r--}" " -
+let b:surround_104 = "{==\r==}{>>\1comment: \1<<}" " h
+let b:surround_99 = "{>>\r<<}" " c
+let b:surround_126 = "{~~\r->\1substitution: \1~~}" " ~
+
 " vim:set sw=2:

--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -1,0 +1,10 @@
+snippet ++
+	{++${1:addition}++}
+snippet --
+	{--${1:deletion}--}
+snippet <<
+	{>>${1:comment}<<}
+snippet ~~
+	{~~${1:old}->${2:new}~~}
+snippet ==
+	{==${1:highlight}==}{>>${2:comment}<<}

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -42,7 +42,7 @@ syn match markdownValid '&\%(#\=\w*;\)\@!'
 syn match markdownLineStart "^[<@]\@!" nextgroup=@markdownBlock,htmlSpecialChar
 
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule
-syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError
+syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError,CMAdd,CMDelete,CMSubstitute
 
 syn match markdownH1 "^.\+\n=\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
 syn match markdownH2 "^.\+\n-\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
@@ -89,6 +89,10 @@ exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=__\|_
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart' . s:concealends
 
+syn region CMAdd start="\S\@<={++\|{++\S\@=" end="\S\@<=++}\|++}\S\@=" keepend contains=markdownLineStart
+syn region CMDelete start="\S\@<={--\|{--\S\@=" end="\S\@<=--}\|--}\S\@=" keepend contains=markdownLineStart
+syn region CMSubstitute start="\S\@<={\~\~\|{\~\~\S\@=" end="\S\@<=\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
+
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*```*.*$" end="^\s*```*\ze\s*$" keepend
@@ -111,6 +115,13 @@ endif
 
 syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
+
+hi CMAdd        guifg=Green
+hi CMDelete     guifg=Red
+hi CMSubstitute guifg=Yellow
+hi def link CMAdd                         CMAdd
+hi def link CMDelete                      CMDelete
+hi def link CMSubstitute                  CMSubstitute
 
 hi def link markdownH1                    htmlH1
 hi def link markdownH2                    htmlH2

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -89,9 +89,9 @@ exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=__\|_
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart' . s:concealends
 
-syn region CMAdd start="\S\@<={++\|{++\S\@=" end="\S\@<=++}\|++}\S\@=" keepend contains=markdownLineStart
-syn region CMDelete start="\S\@<={--\|{--\S\@=" end="\S\@<=--}\|--}\S\@=" keepend contains=markdownLineStart
-syn region CMSubstitute start="\S\@<={\~\~\|{\~\~\S\@=" end="\S\@<=\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
+syn region CMAdd start="\S\@<={++\|{++" end="++}\|++}\S\@=" keepend contains=markdownLineStart
+syn region CMDelete start="\S\@<={--\|{--" end="--}\|--}\S\@=" keepend contains=markdownLineStart
+syn region CMSubstitute start="\S\@<={\~\~\|{\~\~" end="\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -42,7 +42,7 @@ syn match markdownValid '&\%(#\=\w*;\)\@!'
 syn match markdownLineStart "^[<@]\@!" nextgroup=@markdownBlock,htmlSpecialChar
 
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule
-syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError,CMAdd,CMDelete,CMSubstitute
+syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError,CMAdd,CMDelete,CMSubstitute,CMHighlight,CMComment
 
 syn match markdownH1 "^.\+\n=\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
 syn match markdownH2 "^.\+\n-\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
@@ -92,6 +92,8 @@ exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start=
 syn region CMAdd start="\S\@<={++\|{++" end="++}\|++}\S\@=" keepend contains=markdownLineStart
 syn region CMDelete start="\S\@<={--\|{--" end="--}\|--}\S\@=" keepend contains=markdownLineStart
 syn region CMSubstitute start="\S\@<={\~\~\|{\~\~" end="\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
+syn region CMHighlight start="\S\@<={{\|{{" end="}}\|}}\S\@=" keepend contains=markdownLineStart
+syn region CMComment start="\S\@<={>>\|{>>" end="<<}\|<<}\S\@=" keepend contains=markdownLineStart
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
@@ -116,12 +118,17 @@ endif
 syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
 
-hi CMAdd        guifg=Green
-hi CMDelete     guifg=Red
-hi CMSubstitute guifg=Yellow
+hi CMAdd        gui=bold guifg=LimeGreen cterm=bold ctermfg=Green
+hi CMDelete     gui=bold guifg=Red       cterm=bold ctermfg=Red
+hi CMSubstitute gui=bold guifg=goldenrod    cterm=bold ctermfg=Yellow
+hi CMHighlight  gui=bold guifg=Magenta   cterm=bold ctermfg=Magenta
+hi CMComment    gui=bold guifg=DodgerBlue1      cterm=bold ctermfg=Cyan
+
 hi def link CMAdd                         CMAdd
 hi def link CMDelete                      CMDelete
 hi def link CMSubstitute                  CMSubstitute
+hi def link CMHighlight                   CMHighlight
+hi def link CMComment                     CMComment
 
 hi def link markdownH1                    htmlH1
 hi def link markdownH2                    htmlH2

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -92,7 +92,7 @@ exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start=
 syn region CMAdd start="\S\@<={++\|{++" end="++}\|++}\S\@=" keepend contains=markdownLineStart
 syn region CMDelete start="\S\@<={--\|{--" end="--}\|--}\S\@=" keepend contains=markdownLineStart
 syn region CMSubstitute start="\S\@<={\~\~\|{\~\~" end="\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
-syn region CMHighlight start="\S\@<={{\|{{" end="}}\|}}\S\@=" keepend contains=markdownLineStart
+syn region CMHighlight start="\S\@<={==\|{==" end="==}\|==}\S\@=" keepend contains=markdownLineStart
 syn region CMComment start="\S\@<={>>\|{>>" end="<<}\|<<}\S\@=" keepend contains=markdownLineStart
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -12,6 +12,10 @@ if !exists('main_syntax')
   let main_syntax = 'markdown'
 endif
 
+if !exists('g:markdown_criticmarkup')
+  let g:markdown_criticmarkup = 1
+endif
+
 if !exists('g:markdown_criticmarkup_force_colors')
   let g:markdown_criticmarkup_force_colors = 0
 endif
@@ -93,12 +97,6 @@ exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=__\|_
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart' . s:concealends
 
-syn region CMAdd start="\S\@<={++\|{++" end="++}\|++}\S\@=" keepend contains=markdownLineStart
-syn region CMDelete start="\S\@<={--\|{--" end="--}\|--}\S\@=" keepend contains=markdownLineStart
-syn region CMSubstitute start="\S\@<={\~\~\|{\~\~" end="\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
-syn region CMHighlight start="\S\@<={==\|{==" end="==}\|==}\S\@=" keepend contains=markdownLineStart
-syn region CMComment start="\S\@<={>>\|{>>" end="<<}\|<<}\S\@=" keepend contains=markdownLineStart
-
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*```*.*$" end="^\s*```*\ze\s*$" keepend
@@ -109,11 +107,11 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\+\]:"
 if main_syntax ==# 'markdown'
   let s:done_include = {}
   for s:type in g:markdown_fenced_languages
-    if has_key(s:done_include, matchstr(s:type,'[^.]*'))
-      continue
-    endif
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```*\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
-    let s:done_include[matchstr(s:type,'[^.]*')] = 1
+	if has_key(s:done_include, matchstr(s:type,'[^.]*'))
+	  continue
+	endif
+	exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```*\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+	let s:done_include[matchstr(s:type,'[^.]*')] = 1
   endfor
   unlet! s:type
   unlet! s:done_include
@@ -122,18 +120,26 @@ endif
 syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
 
-if get(g:, 'markdown_criticmarkup_force_colors', 1)
-  hi CMAdd        gui=bold guifg=LimeGreen cterm=bold ctermfg=Green
-  hi CMDelete     gui=bold guifg=Red       cterm=bold ctermfg=Red
-  hi CMSubstitute gui=bold guifg=goldenrod    cterm=bold ctermfg=Yellow
-  hi CMHighlight  gui=bold guifg=Magenta   cterm=bold ctermfg=Magenta
-  hi CMComment    gui=bold guifg=DodgerBlue1      cterm=bold ctermfg=Cyan
-else
-  hi def link CMAdd                         Todo
-  hi def link CMDelete                      Error
-  hi def link CMSubstitute                  Search
-  hi def link CMHighlight                   Debug
-  hi def link CMComment                     Comment
+if get(g:, 'markdown_criticmarkup', 1)
+  syn region CMAdd start="\S\@<={++\|{++" end="++}\|++}\S\@=" keepend contains=markdownLineStart
+  syn region CMDelete start="\S\@<={--\|{--" end="--}\|--}\S\@=" keepend contains=markdownLineStart
+  syn region CMSubstitute start="\S\@<={\~\~\|{\~\~" end="\~\~}\|\~\~}\S\@=" keepend contains=markdownLineStart
+  syn region CMHighlight start="\S\@<={==\|{==" end="==}\|==}\S\@=" keepend contains=markdownLineStart
+  syn region CMComment start="\S\@<={>>\|{>>" end="<<}\|<<}\S\@=" keepend contains=markdownLineStart
+
+  if get(g:, 'markdown_criticmarkup_force_colors', 1)
+	hi CMAdd        gui=bold guifg=LimeGreen cterm=bold ctermfg=Green
+	hi CMDelete     gui=bold guifg=Red       cterm=bold ctermfg=Red
+	hi CMSubstitute gui=bold guifg=goldenrod    cterm=bold ctermfg=Yellow
+	hi CMHighlight  gui=bold guifg=Magenta   cterm=bold ctermfg=Magenta
+	hi CMComment    gui=bold guifg=DodgerBlue1      cterm=bold ctermfg=Cyan
+  else
+	hi def link CMAdd                         Todo
+	hi def link CMDelete                      Error
+	hi def link CMSubstitute                  Search
+	hi def link CMHighlight                   Debug
+	hi def link CMComment                     Comment
+  endif
 endif
 
 hi def link markdownH1                    htmlH1

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -12,6 +12,10 @@ if !exists('main_syntax')
   let main_syntax = 'markdown'
 endif
 
+if !exists('g:markdown_criticmarkup_force_colors')
+  let g:markdown_criticmarkup_force_colors = 0
+endif
+
 runtime! syntax/html.vim
 unlet! b:current_syntax
 
@@ -118,17 +122,19 @@ endif
 syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
 syn match markdownError "\w\@<=_\w\@="
 
-hi CMAdd        gui=bold guifg=LimeGreen cterm=bold ctermfg=Green
-hi CMDelete     gui=bold guifg=Red       cterm=bold ctermfg=Red
-hi CMSubstitute gui=bold guifg=goldenrod    cterm=bold ctermfg=Yellow
-hi CMHighlight  gui=bold guifg=Magenta   cterm=bold ctermfg=Magenta
-hi CMComment    gui=bold guifg=DodgerBlue1      cterm=bold ctermfg=Cyan
-
-hi def link CMAdd                         CMAdd
-hi def link CMDelete                      CMDelete
-hi def link CMSubstitute                  CMSubstitute
-hi def link CMHighlight                   CMHighlight
-hi def link CMComment                     CMComment
+if get(g:, 'markdown_criticmarkup_force_colors', 1)
+  hi CMAdd        gui=bold guifg=LimeGreen cterm=bold ctermfg=Green
+  hi CMDelete     gui=bold guifg=Red       cterm=bold ctermfg=Red
+  hi CMSubstitute gui=bold guifg=goldenrod    cterm=bold ctermfg=Yellow
+  hi CMHighlight  gui=bold guifg=Magenta   cterm=bold ctermfg=Magenta
+  hi CMComment    gui=bold guifg=DodgerBlue1      cterm=bold ctermfg=Cyan
+else
+  hi def link CMAdd                         Todo
+  hi def link CMDelete                      Error
+  hi def link CMSubstitute                  Search
+  hi def link CMHighlight                   Debug
+  hi def link CMComment                     Comment
+endif
 
 hi def link markdownH1                    htmlH1
 hi def link markdownH2                    htmlH2


### PR DESCRIPTION
[CriticMarkup](http://criticmarkup.com/) is an increasingly popular extension to Markdown for handling the creative writing editing process. It's made it's way into book publishing workflows based on Markdown.

There has been [a fork of this repo](https://github.com/goldfeld/criticmarkup-vim) out there that adds syntax support for a while, but it has some issues.

1. First it has unfinished code and and the early makings of a plugin with functions for processing the markup. I think this stuff belongs in a separate plugin, but that creates a conflict with syntax highlighting. To address this I've cherry picked out just the stuff related to syntax highlighting and left out the unfinished plugin code.

2. It hard coded colors and didn't have any way to turn the feature on and off. To address this I've added flags to both enable CriticMarkup and optionally to also force the color scheme.

Please let me know what shape this should take to be merged upstream.