### PR TITLE
Highlight trailing whitespace

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -148,7 +148,7 @@ hi def link markdownBoldItalicDelimiter   markdownBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
 
 hi def link markdownEscape                Special
-hi def      markdownImplicitBreak         ctermbg=darkgreen guibg=lightgreen
+hi def link markdownImplicitBreak         Error
 hi def link markdownError                 Error
 
 let b:current_syntax = "markdown"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -110,6 +110,7 @@ if main_syntax ==# 'markdown'
 endif
 
 syn match markdownEscape "\\[][\\`*_{}()<>#+.!-]"
+syn match markdownImplicitBreak "\s*\ \ $" containedin=ALL
 syn match markdownError "\w\@<=_\w\@="
 
 hi def link markdownH1                    htmlH1
@@ -147,6 +148,7 @@ hi def link markdownBoldItalicDelimiter   markdownBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
 
 hi def link markdownEscape                Special
+hi def      markdownImplicitBreak         ctermbg=darkgreen guibg=lightgreen
 hi def link markdownError                 Error
 
 let b:current_syntax = "markdown"


### PR DESCRIPTION
This is a replacement for obsolete PR #52. The original poster has removed their fork and the issues raised in discussion there were never addressed.

This a) rebases the original commit on the current master and b) removes the hard coded color and replaces it with a link to the Error color.

I considered hiding this behind a feature flag, but wasn't sure what the demand would be. For me I can't see a need to _not_ highlight these special meaning characters that are otherwise invisible, but if there is a demand for not having this I could put it behind a flag.