### PR TITLE
Allow toggling of syntax concealing.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,10 @@ documents you can enable it in your `.vimrc` like so:
 
     let g:markdown_fenced_languages = ['html', 'python', 'bash=sh']
 
+To disable markdown syntax concealing add the following to your vimrc:
+
+    let g:markdown_syntax_conceal = 0
+
 ## License
 
 Copyright © Tim Pope.  Distributed under the same terms as Vim itself.

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -81,7 +81,10 @@ syn region markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" conta
 syn region markdownId matchgroup=markdownIdDelimiter start="\[" end="\]" keepend contained
 syn region markdownAutomaticLink matchgroup=markdownUrlDelimiter start="<\%(\w\+:\|[[:alnum:]_+-]\+@\)\@=" end=">" keepend oneline
 
-let s:concealends = has('conceal') ? ' concealends' : ''
+let s:concealends = ''
+if has('conceal') && get(g:, 'markdown_syntax_conceal', 1) == 1
+  let s:concealends = ' concealends'
+endif
 exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\S\@<=_\|_\S\@=" end="\S\@<=_\|_\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend contains=markdownLineStart,markdownItalic' . s:concealends


### PR DESCRIPTION
Adding a small option to turn off syntax concealing (similar to how [vim-json](https://github.com/elzr/vim-json) does it).

