### PR TITLE
Problem: pandoc, jekyll or hugo front matters are not highlighted

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,10 @@ To disable markdown syntax concealing add the following to your vimrc:
 
     let g:markdown_syntax_conceal = 0
 
+To highlight YAML, TOML or JSON front matter as used by Pandoc, Jekyll or Hugo.
+
+    let g:vim_markdown_frontmatter = 1
+
 ## License
 
 Copyright © Tim Pope.  Distributed under the same terms as Vim itself.

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -92,6 +92,31 @@ exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=__\|_
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart,@Spell' . s:concealends
 exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart,@Spell' . s:concealends
 
+if get(g:, 'vim_markdown_frontmatter', 0)
+  " YAML frontmatter
+  syn include @yamlTop syntax/yaml.vim
+  syn region markdownCode matchgroup=markdownCodeDelimiter start="\%^---$" end="^---$" contains=@yamlTop keepend
+  unlet! b:current_syntax
+
+  " TOML frontmatter
+  try
+    syn include @tomlTop syntax/toml.vim
+    syn region markdownCode matchgroup=markdownCodeDelimiter start="\%^+++$" end="^+++$" transparent contains=@tomlTop keepend
+    unlet! b:current_syntax
+  catch /E484/
+    syn region markdownCode matchgroup=markdownCodeDelimiter start="\%^+++$" end="^+++$"
+  endtry
+
+  " JSON frontmatter
+  try
+    syn include @jsonTop syntax/json.vim
+    syn region markdownCode matchgroup=markdownCodeDelimiter start="\%^{$" end="^}$" contains=@jsonTop keepend
+    unlet! b:current_syntax
+  catch /E484/
+    syn region markdownCode matchgroup=markdownCodeDelimiter start="\%^{$" end="^}$"
+  endtry
+endif
+
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*```*.*$" end="^\s*```*\ze\s*$" keepend

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -42,7 +42,7 @@ syn match markdownValid '&\%(#\=\w*;\)\@!'
 syn match markdownLineStart "^[<@]\@!" nextgroup=@markdownBlock,htmlSpecialChar
 
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule
-syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError
+syn cluster markdownInline contains=markdownLineBreak,markdownLinkText,markdownItalic,markdownBold,markdownCode,markdownEscape,@htmlTop,markdownError,markdownMath
 
 syn match markdownH1 "^.\+\n=\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
 syn match markdownH2 "^.\+\n-\+$" contained contains=@markdownInline,markdownHeadingRule,markdownAutomaticLink
@@ -120,6 +120,13 @@ endif
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*```*.*$" end="^\s*```*\ze\s*$" keepend
+
+if get(g:, 'vim_markdown_math', 0)
+  let g:tex_conceal= ''
+  syn include @tex syntax/tex.vim
+  syn region markdownMath start="\\\@<!\$" end="\$" contains=@tex keepend
+  syn region markdownMath start="\\\@<!\$\$" end="\$\$" contains=@tex keepend
+endif
 
 syn match markdownFootnote "\[^[^\]]\+\]"
 syn match markdownFootnoteDefinition "^\[^[^\]]\+\]:"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -137,7 +137,7 @@ if main_syntax ==# 'markdown'
     if has_key(s:done_include, matchstr(s:type,'[^.]*'))
       continue
     endif
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```*\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*```[{\.]*\s*'.matchstr(s:type,'[^=]*').'\>.*$" end="^\s*```*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
     let s:done_include[matchstr(s:type,'[^.]*')] = 1
   endfor
   unlet! s:type


### PR DESCRIPTION
When using tool like pandoc, jekyll, or hugo it is common
to use a YAML, TOML or JSON front matter. These front matter need
different highlighting.

Solution: Use similar approach as for code fences but load yaml,
toml and json syntax manually
