### PR TITLE
Markdown fold text function

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -41,10 +41,35 @@ function! MarkdownFold()
   return "="
 endfunction
 
+function! MarkdownFoldText()
+  let hash_indent = s:HashIndent(v:foldstart)
+  let title = substitute(getline(v:foldstart), '^#\+\s*', '', '')
+  let foldsize = (v:foldend - v:foldstart + 1)
+  let linecount = '['.foldsize.' lines]'
+  return hash_indent.' '.title.' '.linecount
+endfunction
+
+function! s:HashIndent(lnum)
+  let hash_header = matchstr(getline(a:lnum), '^#\{1,6}')
+  if len(hash_header) > 0
+    " hashtag header
+    return hash_header
+  else
+    " == or -- header
+    let nextline = getline(a:lnum + 1)
+    if nextline =~ '^=\+\s*$'
+      return repeat('#', 1)
+    elseif nextline =~ '^-\+\s*$'
+      return repeat('#', 2)
+    endif
+  endif
+endfunction
+
 if has("folding") && exists("g:markdown_folding")
   setlocal foldexpr=MarkdownFold()
   setlocal foldmethod=expr
-  let b:undo_ftplugin .= " foldexpr< foldmethod<"
+  setlocal foldtext=MarkdownFoldText()
+  let b:undo_ftplugin .= " foldexpr< foldmethod< foldtext<"
 endif
 
 " vim:set sw=2:


### PR DESCRIPTION
Adds a foldtext function, for which 'Bonus points' were offered in #10 😜

- Displays == and -- headers as # and ##
- Use markdown header style instead of '+--' to show nesting

Given the example:

    This is Header One
    ==================
    This is Header Two
    -----------------
    ### This is Header Three
    This is a normal line

Instead of:

    +--  6 lines: This is Header One-----------------------------
    +---  4 lines: This is Header Two----------------------------
    +----  2 lines: ### This is Header Three---------------------

You get:

    # This is Header One [6 lines]-------------------------------
    ## This is Header Two [4 lines]------------------------------
    ### This is Header Three [2 lines]----------------------------