### PR TITLE
Customizable minlines with g:markdown_minlines

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,14 @@ To disable markdown syntax concealing add the following to your vimrc:
 
     let g:markdown_syntax_conceal = 0
 
+Syntax highlight is synchronized in 50 lines. It may cause collapsed
+highlighting at large fenced code block.
+In the case, please set larger value in your vimrc:
+
+    let g:markdown_minlines = 100
+
+Note that setting too large value may cause bad performance on highlighting.
+
 ## License
 
 Copyright © Tim Pope.  Distributed under the same terms as Vim itself.

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -33,7 +33,10 @@ endfor
 unlet! s:type
 unlet! s:done_include
 
-syn sync minlines=10
+if !exists('g:markdown_minlines')
+  let g:markdown_minlines = 50
+endif
+execute 'syn sync minlines=' . g:markdown_minlines
 syn case ignore
 
 syn match markdownValid '[<>]\c[a-z/$!]\@!'


### PR DESCRIPTION
## Problem

Currently markdown (including Vim's standard `syntax/markdown.vim`) syntax highlight is synchronized with `syn sync minlines=10`.

However, it causes collapsed highlight at large code block on scrolling a buffer.
This is because the `minlines` config is too small to find the edge of fenced code.

## Solution

I fixed this by making the `minlines` config customizable. If someone has trouble with collapsed highlight with large code block, customizing `g:markdown_minlines` will solve the problem.

I didn't change default value because of compatibility and performance in mind. (Some old PC may causes performance error when increase the value of `g:markdown_minlines`)

Ruby uses the same approach `g:ruby_minlines` because Ruby must also find the `... end` block.

I'd much appreciate if you contribute this change to standard `runtime/syntax/markdown.vim` also.