### PR TITLE
add .mdwn file extension

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,4 +1,4 @@
-autocmd BufNewFile,BufRead *.markdown,*.md,*.mdown,*.mkd,*.mkdn
+autocmd BufNewFile,BufRead *.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.mdwn
       \ if &ft =~# '^\%(conf\|modula2\)$' |
       \   set ft=markdown |
       \ else |


### PR DESCRIPTION
I added .mdwn as one common file extension for markdown files. Even tough it is not mentioned in [RFC7763](https://tools.ietf.org/html/rfc7763), it is used for instance by [ikiwiki](https://ikiwiki.info/) (https://ikiwiki.info/plugins/mdwn/), a popular wiki engine.