### PR TITLE
Avoid infinite syn include recursion when using markdown as a fenced language

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -20,7 +20,7 @@ if !exists('g:markdown_fenced_languages')
 endif
 let s:done_include = {}
 for s:type in map(copy(g:markdown_fenced_languages),'matchstr(v:val,"[^=]*$")')
-  if has_key(s:done_include, matchstr(s:type,'[^.]*'))
+  if has_key(s:done_include, matchstr(s:type,'[^.]*')) || matchstr(s:type,'[^.]*') ==# 'markdown'
     continue
   endif
   if s:type =~ '\.'
@@ -97,7 +97,8 @@ exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start=
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
-syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*````*.*$" end="^\s*````*\ze\s*$" keepend
+syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*````*\%(markdown\)\@!$" end="^\s*````*\ze\s*$" keepend
+syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*````*markdown$" end="^\s*````*\ze\s*$" transparent
 
 syn match markdownFootnote "\[^[^\]]\+\]"
 syn match markdownFootnoteDefinition "^\[^[^\]]\+\]:"
@@ -105,7 +106,7 @@ syn match markdownFootnoteDefinition "^\[^[^\]]\+\]:"
 if main_syntax ==# 'markdown'
   let s:done_include = {}
   for s:type in g:markdown_fenced_languages
-    if has_key(s:done_include, matchstr(s:type,'[^.]*'))
+    if has_key(s:done_include, matchstr(s:type,'[^.]*')) || matchstr(s:type,'[^.]*') ==# 'markdown'
       continue
     endif
     exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*````*\s*'.matchstr(s:type,'[^=]*').'\S\@!.*$" end="^\s*````*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')


### PR DESCRIPTION
Fix #121 

This is reported by @rhysd.
https://github.com/tyru/markdown-codehl-onthefly.vim/pull/3