### PR TITLE
readme: Upstream matches *.md to Markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,13 +4,6 @@ This is the development version of Vim's included syntax highlighting and
 filetype plugins for Markdown.  Generally you don't need to install these if
 you are running a recent version of Vim.
 
-One difference between this repository and the upstream files in Vim is that
-the former forces `*.md` as Markdown, while the latter detects it as Modula-2,
-with an exception for `README.md`.  If you'd like to force Markdown without
-installing from this repository, add the following to your vimrc:
-
-    autocmd BufNewFile,BufReadPost *.md set filetype=markdown
-
 If you want to enable fenced code block syntax highlighting in your markdown
 documents you can enable it in your `.vimrc` like so:
 


### PR DESCRIPTION
Introduced in late 2014:
https://github.com/vim/vim/commit/7d76c804af900ba6dcc4b1e45373ccab3418c6b2#diff-44a099e40ae628aef90a28c6408a4c61R1154