### PR TITLE
Conceal code blocks

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -108,7 +108,7 @@ if main_syntax ==# 'markdown'
     if has_key(s:done_include, matchstr(s:type,'[^.]*'))
       continue
     endif
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*````*\s*'.matchstr(s:type,'[^=]*').'\S\@!.*$" end="^\s*````*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g')
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*````*\s*'.matchstr(s:type,'[^=]*').'\S\@!.*$" end="^\s*````*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
     let s:done_include[matchstr(s:type,'[^.]*')] = 1
   endfor
   unlet! s:type


### PR DESCRIPTION
Conceals the start and end markers of code blocks.
Fixes #114 

Example:

![image](https://user-images.githubusercontent.com/10748726/61696012-cf56fd00-ad34-11e9-9a33-f06cc05d1e02.png)


![image](https://user-images.githubusercontent.com/10748726/61695984-c108e100-ad34-11e9-8c20-c1bfee4b5b4f.png)
