### PR TITLE
Support pandoc syntax for fenced code blocks

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -108,7 +108,7 @@ if main_syntax ==# 'markdown'
     if has_key(s:done_include, matchstr(s:type,'[^.]*'))
       continue
     endif
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*````*\s*'.matchstr(s:type,'[^=]*').'\S\@!.*$" end="^\s*````*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*````*\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*````*\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
     let s:done_include[matchstr(s:type,'[^.]*')] = 1
   endfor
   unlet! s:type


### PR DESCRIPTION
This supports fenced code attributes for pandoc style markdown (see [here](https://pandoc.org/MANUAL.html#extension-fenced_code_attributes)).

In the example Markdown below, this will highlight the code block with bash syntax highlighting (assuming `g:markdown_fenced_languages` is set up properly).
````markdown
Code block:
``` {#my-code-block .numberLines .bash}
foo() {
    bar="1"
    echo $bar
}
```
````