### PR TITLE
Update [[ and ]] mappings

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -19,11 +19,11 @@ else
   let b:undo_ftplugin = "setl cms< com< fo< flp<"
 endif
 
-if !exists("g:no_plugin_maps") || !exists("g:no_markdown_maps")
-  nnoremap <silent><buffer> [[ m':call search('^#\{1,5\}\s\+\S', "bW")<CR>
-  nnoremap <silent><buffer> ]] m':call search('^#\{1,5\}\s\+\S', "W")<CR>
-  xnoremap <silent><buffer> [[ m':<C-U>exe "normal! gv"<Bar>call search('^#\{1,5\}\s\+\S', "bW")<CR>
-  xnoremap <silent><buffer> ]] m':<C-U>exe "normal! gv"<Bar>call search('^#\{1,5\}\s\+\S', "W")<CR>
+if !exists("g:no_plugin_maps") && !exists("g:no_markdown_maps")
+  nnoremap <silent><buffer> [[ :<C-U>call search('\%(^#\{1,5\}\s\+\S\\|^\S.*\n^[=-]\+$\)', "bsW")<CR>
+  nnoremap <silent><buffer> ]] :<C-U>call search('\%(^#\{1,5\}\s\+\S\\|^\S.*\n^[=-]\+$\)', "sW")<CR>
+  xnoremap <silent><buffer> [[ :<C-U>exe "normal! gv"<Bar>call search('\%(^#\{1,5\}\s\+\S\\|^\S.*\n^[=-]\+$\)', "bsW")<CR>
+  xnoremap <silent><buffer> ]] :<C-U>exe "normal! gv"<Bar>call search('\%(^#\{1,5\}\s\+\S\\|^\S.*\n^[=-]\+$\)', "sW")<CR>
   let b:undo_ftplugin .= '|sil! nunmap <buffer> [[|sil! nunmap <buffer> ]]|sil! xunmap <buffer> [[|sil! xunmap <buffer> ]]'
 endif
 


### PR DESCRIPTION
1. Add support for setext style headings
2. Use the 's' flag in `search()` to set the `'` mark instead of using `m'`
3. Fix the guard. Before, the maps would still be created if, e.g. `g:no_markdown_maps` was set but `g:no_plugin_maps` was unset. Likewise if `g:no_plugin_maps` was set but `g:no_markdown_maps` was unset. Only create the maps if _both_ `g:no_plugin_maps` and `g:no_markdown_maps` are unset.