### PR TITLE
Prevent false detection of fenced code block start

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -118,8 +118,8 @@ if main_syntax ==# 'markdown'
     if has_key(s:done_include, matchstr(s:type,'[^.]*'))
       continue
     endif
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)*\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
-    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)*\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
+    exe 'syn region markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight'.substitute(matchstr(s:type,'[^=]*$'),'\.','','g') . s:concealends
     let s:done_include[matchstr(s:type,'[^.]*')] = 1
   endfor
   unlet! s:type


### PR DESCRIPTION
If a line begins (ignoring any space characters) with a *word* that happens to match one of the languages listed in `g:markdown_fenced_languages`, the line is wrongly detected as being the start of a fenced code-block for that language.

As an example, the following line would be highlighted as the start of fenced code block and lines immediately following it are highlighted as SQL statements (until a blank line is reached).

> SQL (Structured Query Language) is a declarative language

![vim-markdown-fenced-code-bug](https://user-images.githubusercontent.com/1758777/78718845-e1a4b580-791a-11ea-9998-1e357af8bbf2.png)

This bug was introduced in the [most recent commit](https://github.com/tpope/vim-markdown/commit/296eeaa8877528fae45e89a9013c5a8d317deef1) where an extraneous asterisk allows for *zero* matches of the `\z(~\{3,\}\)` atom. This pull request should ensure that a line is only treated as the start of a fenced code block if the line begins with three or more consecutive backtick or tilde characters (with optional leading white-space).
