### PR TITLE
Improve markdownRule syntax matching

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -76,8 +76,9 @@ syn region markdownCodeBlock start="    \|\t" end="$" contained
 syn match markdownListMarker "\%(\t\| \{0,4\}\)[-*+]\%(\s\+\S\)\@=" contained
 syn match markdownOrderedListMarker "\%(\t\| \{0,4}\)\<\d\+\.\%(\s\+\S\)\@=" contained
 
-syn match markdownRule "\* *\* *\*[ *]*$" contained
-syn match markdownRule "- *- *-[ -]*$" contained
+syn match markdownRule "^ \{0,3\}\* *\* *\*[ *]*$" contained
+syn match markdownRule "^ \{0,3\}- *- *-[ -]*$" contained
+syn match markdownRule "^ \{0,3\}_ *_ *_[ _]*$" contained
 
 syn match markdownLineBreak " \{2,\}$"
 
@@ -97,12 +98,12 @@ let s:concealends = ''
 if has('conceal') && get(g:, 'markdown_syntax_conceal', 1) == 1
   let s:concealends = ' concealends'
 endif
-exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" skip="\\\*" contains=markdownLineStart,@Spell' . s:concealends
-exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\w\@<!_\S\@=" end="\S\@<=_\w\@!" skip="\\_" contains=markdownLineStart,@Spell' . s:concealends
-exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" skip="\\\*" contains=markdownLineStart,markdownItalic,@Spell' . s:concealends
-exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\w\@<!__\S\@=" end="\S\@<=__\w\@!" skip="\\_" contains=markdownLineStart,markdownItalic,@Spell' . s:concealends
-exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" skip="\\\*" contains=markdownLineStart,@Spell' . s:concealends
-exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\w\@<!___\S\@=" end="\S\@<=___\w\@!" skip="\\_" contains=markdownLineStart,@Spell' . s:concealends
+exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\%(\S\&[^\*]\)\@<=\*\|\*\%(\S\&[^\*]\)\@=" end="\S\@<=\*\|\*\S\@=" skip="\\\*" contains=markdownLineStart,@Spell' . s:concealends
+exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\w\@<!_\%(\S\&[^_]\)\@=" end="\S\@<=_\w\@!" skip="\\_" contains=markdownLineStart,@Spell' . s:concealends
+exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\%(\S\&[^\*]\)\@<=\*\*\|\*\*\%(\S\&[^\*]\)\@=" end="\S\@<=\*\*\|\*\*\S\@=" skip="\\\*" contains=markdownLineStart,markdownItalic,@Spell' . s:concealends
+exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\w\@<!__\%(\S\&[^_]\)\@=" end="\S\@<=__\w\@!" skip="\\_" contains=markdownLineStart,markdownItalic,@Spell' . s:concealends
+exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\%(\S\&[^\*]\)\@<=\*\*\*\|\*\*\*\%(\S\&[^\*]\)\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" skip="\\\*" contains=markdownLineStart,@Spell' . s:concealends
+exe 'syn region markdownBoldItalic matchgroup=markdownBoldItalicDelimiter start="\w\@<!___\%(\S\&[^_]\)\@=" end="\S\@<=___\w\@!" skip="\\_" contains=markdownLineStart,@Spell' . s:concealends
 
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart


### PR DESCRIPTION
- `markdownRule` now only matches if a line contains 0-3 spaces followed by the characters forming the rule (e.g. `␣␣*␣*␣*␣*␣*`), with nothing else on the line. This is in accordance with [CommonMark][CommonMark] (and compatible with [the original spec][Gruber], which does not allow whitespace before the characters forming the rule).
- A horizontal rule can also be formed by underscores, in accordance with [the original spec][Gruber] and [CommonMark][CommonMark].
- An italic, bold, or bold-italic region is no longer started if the delimiter is adjacent to a copy of itself (possibly with whitespace in between). For example, an italic or bold region delimited by asterisks would not begin if the beginning asterisk(s) is/are adjacent to another asterisk. This should not have any practical consequences (italic/bold regions consisting only of whitespace would not be matched), other than that horizontal rules made of asterisks or underscores will now be matched and highlighted properly.

<details>
<summary>Screenshot</summary>

![Screenshot at 2020-06-04 11-46-06](https://user-images.githubusercontent.com/45520974/83779099-81e83380-a659-11ea-9bd7-9f2ec2e22b99.png)

</details>

[CommonMark]: https://spec.commonmark.org/0.29/
[Gruber]: https://daringfireball.net/projects/markdown/syntax