### PR TITLE
Don't let fenced languages change &foldtext

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -14,6 +14,7 @@ endif
 
 if has('folding')
   let s:foldmethod = &l:foldmethod
+  let s:foldtext = &l:foldtext
 endif
 
 runtime! syntax/html.vim
@@ -40,6 +41,10 @@ unlet! s:done_include
 if exists('s:foldmethod') && s:foldmethod !=# &l:foldmethod
   let &l:foldmethod = s:foldmethod
   unlet s:foldmethod
+endif
+if exists('s:foldtext') && s:foldtext !=# &l:foldtext
+  let &l:foldtext = s:foldtext
+  unlet s:foldtext
 endif
 
 if !exists('g:markdown_minlines')


### PR DESCRIPTION
Addresses the sequel to issue #154.
See https://github.com/tpope/vim-markdown/issues/154#issuecomment-778677280