### PR TITLE
syntax: add style for markdownCode

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -173,6 +173,8 @@ hi def link markdownBoldDelimiter         markdownBold
 hi def link markdownBoldItalic            htmlBoldItalic
 hi def link markdownBoldItalicDelimiter   markdownBoldItalic
 hi def link markdownCodeDelimiter         Delimiter
+hi def link markdownCode                  String
+hi def link markdownCodeBlock             String
 
 hi def link markdownEscape                Special
 hi def link markdownError                 Error


### PR DESCRIPTION
and markdownCodeBlock. Choosing `String` as per:

https://github.com/plasticboy/vim-markdown/blob/8e5d86f7/syntax/markdown.vim#L162