### PR TITLE
Fix undo_ftplugin

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -76,7 +76,7 @@ if has("folding") && get(g:, "markdown_folding", 0)
   setlocal foldexpr=MarkdownFold()
   setlocal foldmethod=expr
   setlocal foldtext=MarkdownFoldText()
-  let b:undo_ftplugin .= " foldexpr< foldmethod< foldtext<"
+  let b:undo_ftplugin .= "|setl foldexpr< foldmethod< foldtext<"
 endif
 
 " vim:set sw=2:


### PR DESCRIPTION
Add the missing bar and setl command, which previously hadn't been
necessary until the addition of [[ and ]] maps.