### PR TITLE
Set dummy indentexpr to prevent C-indenting

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -12,11 +12,12 @@ runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
 setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=<!--%s-->
 setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^\\s*[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:\\&^.\\{4\\}
+setlocal indentexpr=-1
 
 if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= "|setl cms< com< fo< flp<"
+  let b:undo_ftplugin .= "|setl cms< com< fo< flp< inde<"
 else
-  let b:undo_ftplugin = "setl cms< com< fo< flp<"
+  let b:undo_ftplugin = "setl cms< com< fo< flp< inde<"
 endif
 
 if !exists("g:no_plugin_maps") && !exists("g:no_markdown_maps")


### PR DESCRIPTION
vim-surround runs `=` after inserting parentheses. If `equalprg` and `indentexpr` are empty, `=` does C-indenting, which usually messes up formatting of markdown documents. Setting `indentexpr` to -1 makes `=` no-op.

I sneaked this change into `ftplugin/` instead of `indent/` because I believe it doesn't do anything special or intrusive that deserves a new file. 