### PR TITLE
Support more kinds of lists

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -11,7 +11,7 @@ runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
 
 setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=<!--%s-->
 setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
-setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^\\s*[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:\\&^.\\{4\\}
+setlocal formatlistpat=^\\s*\\S\\+[.)]\\s\\+\\\|^\\s*[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:\\&^.\\{4\\}
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= "|setl cms< com< fo< flp< et< ts< sts< sw<"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -87,7 +87,7 @@ syn region markdownCodeBlock start="^\n\( \{4,}\|\t\)" end="^\ze \{,3}\S.*$" kee
 
 " TODO: real nesting
 syn match markdownListMarker "\%(\t\| \{0,4\}\)[-*+]\%(\s\+\S\)\@=" contained
-syn match markdownOrderedListMarker "\%(\t\| \{0,4}\)\<\d\+\.\%(\s\+\S\)\@=" contained
+syn match markdownOrderedListMarker "\%(\t\| \{0,4}\)\<\S\+[.)]\%(\s\+\S\)\@=" contained
 
 syn match markdownRule "\* *\* *\*[ *]*$" contained
 syn match markdownRule "- *- *-[ -]*$" contained


### PR DESCRIPTION
Currently, The only Markdown ordered lists for vim-markdown that are supported are numbered ones with a period (e.g. `1.`, `2.`). However, there are more types of lists. You can use letters (e.g. `a.`, `b.`) and even hashtags if you use Pandoc Markdown (`#.`). Additionally, you do not have to put a period, you can put a closing parentheses instead (`#)`). I believe these changes should also be the default for the main Vim repository but I am pull requesting here first.