### PR TITLE
Fix fold inside code fences, again

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -35,7 +35,7 @@ if !exists("g:no_plugin_maps") && !exists("g:no_markdown_maps")
 endif
 
 function! s:NotCodeBlock(lnum) abort
-  return synIDattr(synID(a:lnum, 1, 1), 'name') !=# 'markdownCode'
+  return synIDattr(synID(a:lnum, 1, 1), 'name') !=# 'markdownCodeBlock'
 endfunction
 
 function! MarkdownFold() abort


### PR DESCRIPTION
Fix <https://github.com/tpope/vim-markdown/issues/161> and <https://github.com/tpope/vim-markdown/pull/178> (again)

I recently find that this issue <https://github.com/tpope/vim-markdown/pull/178> still exists. My old pull request <https://github.com/tpope/vim-markdown/pull/178> to fix this issue doesn't work anymore.

The problem is still here: <https://github.com/tpope/vim-markdown/blob/feadbc81e27f277187c29957ec6114f1e95f2162/ftplugin/markdown.vim#L38>

After some debugging, I find that replace `markdownCode` with `markdownCodeBlock` works, as code suggestions from <https://github.com/tpope/vim-markdown/issues/161>. The weird thing is in the past, codes inside three backticks are parsed as `markdownCode`. It seems incorrect but I never think more about it. I think that's why our old codes uses `markdownCode` instead of `markdownCodeBlock`. But now, it is parsed as `markdownCodeBlock`.