### PR TITLE
Allow colons after language identifiers in fenced code blocks for consistent syntax highlighting

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -131,8 +131,8 @@ for s:type in g:markdown_fenced_languages
   if has_key(s:done_include, matchstr(s:type,'[^.]*'))
     continue
   endif
-  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^\s:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
-  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^\s:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
+  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^[:space:]:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
+  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^[:space:]:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
   let s:done_include[matchstr(s:type,'[^.]*')] = 1
 endfor
 unlet! s:type

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -131,8 +131,8 @@ for s:type in g:markdown_fenced_languages
   if has_key(s:done_include, matchstr(s:type,'[^.]*'))
     continue
   endif
-  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
-  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=\S\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
+  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(`\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^\s:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
+  exe 'syn region markdownHighlight_'.substitute(matchstr(s:type,'[^=]*$'),'\..*','','').' matchgroup=markdownCodeDelimiter start="^\s*\z(\~\{3,\}\)\s*\%({.\{-}\.\)\='.matchstr(s:type,'[^=]*').'}\=[^\s:]\@!.*$" end="^\s*\z1\ze\s*$" keepend contains=@markdownHighlight_'.tr(matchstr(s:type,'[^=]*$'),'.','_') . s:concealends
   let s:done_include[matchstr(s:type,'[^.]*')] = 1
 endfor
 unlet! s:type


### PR DESCRIPTION
## Summary

This change makes it possible to include a colon (e.g. `javascript:foo.js`) right after the language identifier in fenced code blocks without disrupting syntax highlighting.
Similar to how other editors (e.g. VSCode) handle these cases, syntax detection will continue to recognize the intended language even if a colon and additional text follow the identifier.

## Details

- Modifies the syntax region definitions so that a colon immediately following the language specifier does not prevent the language from being detected.  
- Aligns behavior with popular editors, ensuring a more consistent experience for users who rely on this notation.

## Testing

- Confirmed that fenced code blocks with `javascript:foo.js` and similar patterns retain correct syntax highlighting.  
- Ensured no regressions in standard language specs and curly-brace class attributes.

## Note

No changes were made to how attributes in curly braces are handled; they remain fully supported.
